### PR TITLE
Showcase versioning options in vcpkg

### DIFF
--- a/vcpkg_project/setup_vcpkg.cmake
+++ b/vcpkg_project/setup_vcpkg.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
         vcpkg
         GIT_REPOSITORY https://github.com/microsoft/vcpkg
-        GIT_TAG 5568f110b509a9fd90711978a7cb76bae75bb092 # 2021.05.12
+        GIT_TAG 4474aba1e77be2d643eb684298b7d5479cad9a1f
 )
 
 if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)

--- a/vcpkg_project/vcpkg.json
+++ b/vcpkg_project/vcpkg.json
@@ -2,9 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "depend-on-me",
   "version": "0.1",
+  "builtin-baseline": "4474aba1e77be2d643eb684298b7d5479cad9a1f",
   "dependencies": [
     "sfml",
     "fmt",
-    "catch2"
+    { "name": "catch2", "version>=": "2.13.7" }
+  ],
+  "overrides": [
+    { "name": "fmt", "version": "8.0.1" }
   ]
 }


### PR DESCRIPTION
Had to also update the referenced `GIT_TAG` (which is apparently just any arbitrary hash, another win for CMake's quality), so that the downloaded ports are up to date and the required versions exist.

This could probably be done through `vcpkg-configuration.json` instead, but when I tried that I ran into problems with building openAL and decided that I am not going to deal with this today.