### PR TITLE
fetch_content and find_package: a workaround for compatibility

### DIFF
--- a/cpm_project/setup_cpm.cmake
+++ b/cpm_project/setup_cpm.cmake
@@ -4,6 +4,21 @@ if (NOT EXISTS "${CMAKE_BINARY_DIR}/CPM.cmake")
          "${CMAKE_BINARY_DIR}/CPM.cmake")
 endif ()
 
+# Note: when you shadow a function, the previous definition
+# is still available by prefixing with an underscore
+
+# Idea from C++Now2017: Daniel Pfeifer "Effective CMake"
+# https://youtu.be/bsXLMQ6WgIk?t=3159
+# Note: there appears to be a typo in the presentation slides.
+# We need to check ${ARGV0}, not ${ARG0}.
+macro(find_package)
+        if(NOT "${ARGV0}" IN_LIST CPM_PACKAGES)
+                _find_package(${ARGV})
+        else()
+                message(DEBUG "${ARGV0} already added by CPM")
+        endif()
+endmacro()
+
 include(${CMAKE_BINARY_DIR}/CPM.cmake)
 CPMAddPackage("gh:catchorg/Catch2#v2.13.7")
 CPMAddPackage("gh:fmtlib/fmt#8.0.1")

--- a/cpm_project/src/CMakeLists.txt
+++ b/cpm_project/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(SFML COMPONENTS
+             audio graphics system window
+             CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+
 add_executable(sfml_program main.cpp)
 target_link_libraries(sfml_program PUBLIC
                       fmt::fmt

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -1,27 +1,11 @@
 include(FetchContent)
 
-# a list of stuff for find_package to ignore
-set(handled_by_fetch_content "")
+# A hack that lets FetchContent cooperate with find_package
+set(handled_by_fetch_content "") # a list of packages for find_package to ignore
 
-FetchContent_Declare(Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.13.7)
-FetchContent_MakeAvailable(Catch2)
-list(APPEND handled_by_fetch_content Catch2)
+# Note: when you shadow a function, the previous definition
+# is still available by prefixing with an underscore
 
-FetchContent_Declare(fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 8.0.1)
-FetchContent_MakeAvailable(fmt)
-list(APPEND handled_by_fetch_content fmt)
-
-FetchContent_Declare(SFML
-        GIT_REPOSITORY https://github.com/SFML/SFML.git
-        GIT_TAG 2.5.1)
-FetchContent_MakeAvailable(SFML)
-list(APPEND handled_by_fetch_content SFML)
-
-# the original find_package gets renamed to _find_package
 # Idea from C++Now2017: Daniel Pfeifer "Effective CMake"
 # https://youtu.be/bsXLMQ6WgIk?t=3159
 # Note: there appears to be a typo in the presentation slides.
@@ -33,3 +17,24 @@ macro(find_package)
                 message(DEBUG "${ARGV0} already fetched")
         endif()
 endmacro()
+
+macro(FetchContent_MakeAvailable)
+        list(APPEND handled_by_fetch_content ${ARGV0})
+        _FetchContent_MakeAvailable(${ARGV})
+endmacro()
+
+FetchContent_Declare(Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v2.13.7)
+FetchContent_MakeAvailable(Catch2)
+
+FetchContent_Declare(fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 8.0.1)
+FetchContent_MakeAvailable(fmt)
+
+FetchContent_Declare(SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG 2.5.1)
+FetchContent_MakeAvailable(SFML)
+

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 
 # A hack that lets FetchContent cooperate with find_package
-set(handled_by_fetch_content "") # a list of packages for find_package to ignore
+set(HANDLED_BY_FETCH_CONTENT "") # a list of packages for find_package to ignore
 
 # Note: when you shadow a function, the previous definition
 # is still available by prefixing with an underscore
@@ -11,7 +11,7 @@ set(handled_by_fetch_content "") # a list of packages for find_package to ignore
 # Note: there appears to be a typo in the presentation slides.
 # We need to check ${ARGV0}, not ${ARG0}.
 macro(find_package)
-        if(NOT "${ARGV0}" IN_LIST handled_by_fetch_content)
+        if(NOT "${ARGV0}" IN_LIST HANDLED_BY_FETCH_CONTENT)
                 _find_package(${ARGV})
         else()
                 message(DEBUG "${ARGV0} already fetched")
@@ -19,7 +19,7 @@ macro(find_package)
 endmacro()
 
 macro(FetchContent_MakeAvailable)
-        list(APPEND handled_by_fetch_content ${ARGV0})
+        list(APPEND HANDLED_BY_FETCH_CONTENT ${ARGV0})
         _FetchContent_MakeAvailable(${ARGV})
 endmacro()
 

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -1,19 +1,29 @@
 include(FetchContent)
 
+set(handled_by_fetch_content "")
+
 FetchContent_Declare(Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
         GIT_TAG        v2.13.7)
 FetchContent_MakeAvailable(Catch2)
+list(APPEND handled_by_fetch_content Catch2)
 
 FetchContent_Declare(fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
         GIT_TAG 8.0.1)
 FetchContent_MakeAvailable(fmt)
+list(APPEND handled_by_fetch_content fmt)
 
 FetchContent_Declare(SFML
         GIT_REPOSITORY https://github.com/SFML/SFML.git
         GIT_TAG 2.5.1)
 FetchContent_MakeAvailable(SFML)
+list(APPEND handled_by_fetch_content SFML)
 
-function(noop_find_package)
-endfunction()
+macro(find_package)
+        if(NOT "${ARGV0}" IN_LIST handled_by_fetch_content)
+                _find_package(${ARGV})
+        else()
+                message(DEBUG "${ARGV0} already fetched")
+        endif()
+endmacro()

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -37,4 +37,3 @@ FetchContent_Declare(SFML
         GIT_REPOSITORY https://github.com/SFML/SFML.git
         GIT_TAG 2.5.1)
 FetchContent_MakeAvailable(SFML)
-

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -1,5 +1,6 @@
 include(FetchContent)
 
+# a list of stuff for find_package to ignore
 set(handled_by_fetch_content "")
 
 FetchContent_Declare(Catch2
@@ -20,6 +21,11 @@ FetchContent_Declare(SFML
 FetchContent_MakeAvailable(SFML)
 list(APPEND handled_by_fetch_content SFML)
 
+# the original find_package gets renamed to _find_package
+# Idea from C++Now2017: Daniel Pfeifer "Effective CMake"
+# https://youtu.be/bsXLMQ6WgIk?t=3159
+# Note: there appears to be a typo in the presentation slides.
+# We need to check ${ARGV0}, not ${ARG0}.
 macro(find_package)
         if(NOT "${ARGV0}" IN_LIST handled_by_fetch_content)
                 _find_package(${ARGV})

--- a/fetch_content_project/setup_fetch_content.cmake
+++ b/fetch_content_project/setup_fetch_content.cmake
@@ -14,3 +14,6 @@ FetchContent_Declare(SFML
         GIT_REPOSITORY https://github.com/SFML/SFML.git
         GIT_TAG 2.5.1)
 FetchContent_MakeAvailable(SFML)
+
+function(noop_find_package)
+endfunction()

--- a/fetch_content_project/src/CMakeLists.txt
+++ b/fetch_content_project/src/CMakeLists.txt
@@ -1,7 +1,7 @@
-noop_find_package(SFML COMPONENTS
+find_package(SFML COMPONENTS
              audio graphics system window
              CONFIG REQUIRED)
-noop_find_package(fmt CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
 
 add_executable(sfml_program main.cpp)
 target_link_libraries(sfml_program PUBLIC

--- a/fetch_content_project/src/CMakeLists.txt
+++ b/fetch_content_project/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+noop_find_package(SFML COMPONENTS
+             audio graphics system window
+             CONFIG REQUIRED)
+noop_find_package(fmt CONFIG REQUIRED)
+
 add_executable(sfml_program main.cpp)
 target_link_libraries(sfml_program PUBLIC
                       fmt::fmt

--- a/fetch_content_project/test/CMakeLists.txt
+++ b/fetch_content_project/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED)
+
 add_executable(tests_fetch_content test.cpp)
 target_link_libraries(tests_fetch_content Catch2::Catch2)
 


### PR DESCRIPTION
I took the idea from [C++Now2017: Daniel Pfeifer "Effective CMake" ](https://youtu.be/bsXLMQ6WgIk?t=3159)

The ideal is to use `find_package` to declare dependencies regardless of how we manage them. To get this to work with `fetch_content`,  redefine `find_package` to ignore packages that have already been fetched and made available with `fetch_content`. 

We rely on the following CMake quirk to modify `find_package`'s behavior:

when you redefine a function, such as `find_package`, the old definition is still accessible via prefixing with an underscore, `_find_package`.  

So I made a list that stores the names of already-fetched packages, taught `FetchContent_MakeAvailable` to append the now-available content to this list, and redefined `find_package` to only forward its input to `_find_package` if the input is not in the already-fetched list. 

I'm a little worried about redefining things, especially because I don't know what happens if multiple libraries try to do something like this. But if we can get `find_package` working consistently, that's less of a problem because we can plug in a different approach to managing the dependencies but keep the project declarations the same. 
